### PR TITLE
feat: guard LLM construction

### DIFF
--- a/ai_module.py
+++ b/ai_module.py
@@ -17,6 +17,7 @@ import numpy as np
 import pandas as pd
 import random
 import collections
+from pathlib import Path
 from config import LLM_MODEL_PATH, RL_ENV_PARAMS
 from backtester import backtest
 from strategy_modifier import add_new_strategy
@@ -217,7 +218,13 @@ class TradingDQN:
 
 class AIModule:
     def __init__(self):
-        self.llm = Llama(model_path=LLM_MODEL_PATH, n_ctx=512, n_batch=512) if Llama else None
+        model_path = Path(LLM_MODEL_PATH) if LLM_MODEL_PATH else None
+        if Llama and model_path and model_path.is_file():
+            self.llm = Llama(model_path=LLM_MODEL_PATH, n_ctx=512, n_batch=512)
+        else:
+            if not (model_path and model_path.is_file()):
+                logger.warning("LLM model path not set; proceeding without local LLM")
+            self.llm = None
         self.rl_model = None
         self.dqn = None
         self.genetic_optimizer = None


### PR DESCRIPTION
## Summary
- avoid ValueError when LLM model path is missing by checking file existence
- warn when LLM model path not set and skip local LLM initialization

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68add2ecbe708327b1c4e3de7200c903