### PR TITLE
Add pytest-mock dependency and document test setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ llama-cpp-python==0.2.89
 gym==0.26.2
 stable-baselines3==2.3.2
 gymnasium==0.29.1
+pytest-mock

--- a/text.txt
+++ b/text.txt
@@ -11,3 +11,12 @@ mt5_trading_bot/
 ├── requirements.txt        # Dependencies
 ├── main.py                 # Entry point for running the bot
 └── data/                   # Folder for historical data (e.g., CSVs)
+
+## Testing
+
+Install dependencies and run the test suite with:
+
+    pip install -r requirements.txt
+    pytest
+
+The tests use the `pytest-mock` plugin for the `mocker` fixture.


### PR DESCRIPTION
## Summary
- include `pytest-mock` plugin in requirements for access to the `mocker` fixture
- add testing instructions referencing `pytest-mock` to project docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeb6b750348327aa9a6fa55d9c2510