### PR TITLE
Add MockBroker fallback in monitor

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -1,19 +1,28 @@
 import logging
-from mt5_trading_bot.broker_interface import MT5Broker
 import time
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+try:
+    from mt5_trading_bot.broker_interface import MT5Broker as Broker
+except Exception as e:  # pragma: no cover - fallback when MT5Broker isn't available
+    from mt5_trading_bot.broker_interface import MockBroker as Broker
+    logger.warning(f"Falling back to MockBroker: {e}")
+
+
 def monitor_bot():
-    broker = MT5Broker()
+    broker = Broker()
     while True:
         positions = broker.get_open_positions()
         for pos in positions:
-            logger.info(f"Position: {pos.ticket}, Type: {'Buy' if pos.type == 1 else 'Sell'}, "
-                        f"Price: {pos.price_open}, SL: {pos.sl}")
+            logger.info(
+                f"Position: {pos.ticket}, Type: {'Buy' if pos.type == 1 else 'Sell'}, "
+                f"Price: {pos.price_open}, SL: {pos.sl}"
+            )
         time.sleep(300)  # Check every 5 minutes
     broker.close()
+
 
 if __name__ == "__main__":
     monitor_bot()


### PR DESCRIPTION
## Summary
- Handle MT5Broker import failures in `monitor_bot` by falling back to `MockBroker`
- Instantiate the broker using whichever class is available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb6be3eb48327958e94068e7bb58c