### PR TITLE
Handle MetaTrader5 stub and optional dependency

### DIFF
--- a/broker_interface.py
+++ b/broker_interface.py
@@ -28,8 +28,10 @@ from config import MT5_ACCOUNT, MT5_PASSWORD, MT5_SERVER, MT5_PATH
 
 try:  # MetaTrader5 is optional – tests may run without it
     import MetaTrader5 as mt5  # type: ignore
+    MT5_STUB = getattr(mt5, "META_TRADER5_STUB", False)
 except Exception:  # pragma: no cover - executed when MT5 isn't installed
-    mt5 = None
+    import metatrader5_stub as mt5  # type: ignore
+    MT5_STUB = True
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +39,7 @@ class MT5Broker:
     """Broker implementation backed by MetaTrader5."""
 
     def __init__(self) -> None:
-        if mt5 is None:
+        if MT5_STUB:
             raise RuntimeError("MetaTrader5 package is not available")
         if not mt5.initialize(path=MT5_PATH):
             raise Exception("MT5 initialization failed")

--- a/main.py
+++ b/main.py
@@ -24,9 +24,7 @@ except ImportError as e:  # pragma: no cover - executed when pandas isn't availa
 try:  # MetaTrader5 may not be installed in some environments
     import MetaTrader5 as mt5  # type: ignore
 except Exception:  # pragma: no cover - executed when MT5 isn't available
-    from types import SimpleNamespace
-
-    mt5 = SimpleNamespace(ORDER_TYPE_BUY=0, ORDER_TYPE_SELL=1)
+    import metatrader5_stub as mt5  # type: ignore
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/metatrader5_stub.py
+++ b/metatrader5_stub.py
@@ -1,33 +1,66 @@
+META_TRADER5_STUB = True
+
 class SymbolInfo:
     def __init__(self, symbol: str):
         self.symbol = symbol
         self.point = 0.0001
         self.trade_contract_size = 100000
 
+class SymbolInfoTick:
+    def __init__(self):
+        self.ask = 1.0
+        self.bid = 1.0
+
 class OrderSendResult:
     def __init__(self):
         self.retcode = TRADE_RETCODE_DONE
         self.comment = ""
 
-TRADE_RETCODE_DONE = 0
+ORDER_TYPE_BUY = 0
+ORDER_TYPE_SELL = 1
+TRADE_ACTION_DEAL = 1
+TRADE_ACTION_CLOSE_BY = 2
 TRADE_ACTION_MODIFY = 6
+TRADE_RETCODE_DONE = 0
 ORDER_TIME_GTC = 1
 ORDER_FILLING_IOC = 1
+
 
 def initialize(*args, **kwargs):
     return True
 
+
 def shutdown():
     return True
+
 
 def login(*args, **kwargs):
     return True
 
+
+def symbol_select(symbol, enable):
+    return True
+
+
 def symbol_info(symbol):
     return SymbolInfo(symbol)
 
+
+def symbol_info_tick(symbol):
+    return SymbolInfoTick()
+
+
+def copy_rates_from_pos(symbol, timeframe, start_pos, count):
+    return []
+
+
+def copy_rates_range(symbol, timeframe, from_date, to_date):
+    return []
+
+
 def positions_get(*args, **kwargs):
     return []
+
 
 def order_send(request):
     return OrderSendResult()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-MetaTrader5>=5.0.45
+MetaTrader5>=5.0.45; platform_system == "Windows"
 TA-Lib==0.6.5
 pandas==2.2.2
 numpy>=1.26.4

--- a/risk_manager.py
+++ b/risk_manager.py
@@ -17,7 +17,10 @@ try:  # Optional dependency – TA‑Lib provides many indicators
 except Exception:  # pragma: no cover - executed when TA‑Lib isn't installed
     talib = None
 
-import MetaTrader5 as mt5  # this is a tiny stub during testing
+try:
+    import MetaTrader5 as mt5  # type: ignore
+except Exception:  # pragma: no cover - executed when MT5 isn't installed
+    import metatrader5_stub as mt5  # type: ignore
 
 from config import RISK_PER_TRADE, INITIAL_CAPITAL
 

--- a/test_risk_manager.py
+++ b/test_risk_manager.py
@@ -2,7 +2,10 @@ import pandas as pd
 import numpy as np
 from mt5_trading_bot.risk_manager import RiskManager
 import pytest
-import MetaTrader5 as mt5
+try:
+    import MetaTrader5 as mt5
+except Exception:  # pragma: no cover - executed when MT5 isn't installed
+    import metatrader5_stub as mt5
 
 @pytest.fixture
 def sample_df():
@@ -15,7 +18,7 @@ def sample_df():
 
 def test_calculate_position_size(sample_df, mocker):
     mt5.initialize()
-    mocker.patch('MetaTrader5.symbol_info', return_value=mt5.SymbolInfo(symbol="EURUSD"))
+    mocker.patch('mt5_trading_bot.risk_manager.mt5.symbol_info', return_value=mt5.SymbolInfo(symbol="EURUSD"))
     rm = RiskManager(10000)
     size = rm.calculate_position_size(1.1000, 1.0950, "EURUSD")
     assert size > 0.01 and size <= 10.0  # Reasonable range


### PR DESCRIPTION
## Summary
- Avoid shadowing the real MetaTrader5 package by renaming the local stub and loading it only when the real library is unavailable
- Guard MT5 broker usage when the stub is active and fall back to the mock broker
- Make MetaTrader5 optional in requirements for non-Windows platforms and update tests accordingly

## Testing
- `pip install -r requirements.txt` *(failed: Building wheel for llama-cpp-python (pyproject.toml): finished with status 'canceled')*
- `pip install pandas numpy pytest-mock`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aebd52950c8327bbe487c259c426e0