### PR TITLE
Enhance AI startup script and add DQN trader

### DIFF
--- a/start_ai.py
+++ b/start_ai.py
@@ -1,0 +1,93 @@
+"""Utility script to run multi-timeframe backtests and prepare an RL environment.
+
+The script loads up to five years of historical data from a CSV file, computes a
+large set of indicators, applies up to 300 available strategies, and reports the
+Sharpe ratio for each strategy across multiple timeframes. It also instantiates
+the reinforcement learning environment defined in ``ai_module`` so further
+training can be layered on top. The heavy lifting of computing hundreds of
+indicators and strategy variations is handled by ``indicators.py`` and
+``strategies.py``.
+
+Usage:
+    python start_ai.py data/historical.csv
+
+The CSV must contain columns: Date, Open, High, Low, Close, Volume.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import timedelta
+from typing import List
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pandas as pd
+
+import strategies
+from indicators import get_all_indicators
+from backtester import backtest
+from strategy_manager import StrategyManager
+from ai_module import TradingEnv, AIModule
+from config import RL_ENV_PARAMS
+
+try:  # Optional torch dependency for saving trained models
+    import torch
+except Exception:  # pragma: no cover - torch is optional
+    torch = None
+
+logger = logging.getLogger(__name__)
+
+
+def load_recent_data(path: str, years: int = 5) -> pd.DataFrame:
+    """Load CSV data and keep only the most recent ``years`` of records."""
+    df = pd.read_csv(path, parse_dates=["Date"])
+    end = df["Date"].max()
+    start = end - timedelta(days=years * 365)
+    return df[df["Date"].between(start, end)].set_index("Date")
+
+
+def run_multi_timeframe_backtests(df: pd.DataFrame, timeframes: List[str]) -> None:
+    """Run backtests for each strategy and timeframe, logging Sharpe ratios."""
+    strategy_names = list(strategies.strategies.keys())[:300]
+    StrategyManager(strategy_names)  # Ensure strategies are validated
+
+    def _run(strat: str, tf: str) -> tuple[str, str, float]:
+        result = backtest(df.copy(), strat, timeframe=tf)
+        return strat, tf, result["sharpe"]
+
+    for tf in timeframes:
+        logger.info("Running %s backtests with %d strategies", tf, len(strategy_names))
+        with ThreadPoolExecutor() as executor:
+            futures = {executor.submit(_run, strat, tf): strat for strat in strategy_names}
+            for future in as_completed(futures):
+                strat, timeframe, sharpe = future.result()
+                logger.info("%s @ %s Sharpe: %.4f", strat, timeframe, sharpe)
+
+
+def train_rl_agent(df: pd.DataFrame) -> None:
+    """Train the DQN agent on the provided data and persist the model if possible."""
+    env = TradingEnv(df)
+    ai = AIModule()
+    ai.init_dqn(RL_ENV_PARAMS["state_size"], RL_ENV_PARAMS["action_size"])
+    ai.train_dqn(env, episodes=10, batch_size=32)
+    if ai.dqn and ai.dqn.model and torch is not None:
+        torch.save(ai.dqn.model.state_dict(), "trained_dqn.pth")
+        logger.info("Saved trained DQN model to trained_dqn.pth")
+
+
+def main(csv_path: str) -> None:
+    df = load_recent_data(csv_path)
+    df = get_all_indicators(df)
+    run_multi_timeframe_backtests(df, ["M1", "H1", "D1"])
+    env = TradingEnv(df)
+    logger.info("RL environment with %d steps ready", len(df))
+    train_rl_agent(df)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    if len(sys.argv) < 2:
+        print("Usage: python start_ai.py path/to/historical.csv")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/start_trader.py
+++ b/start_trader.py
@@ -1,0 +1,62 @@
+"""Run a trading simulation using a previously trained DQN model.
+
+The script loads recent market data, computes indicators, restores a saved
+DQN model and executes actions within the ``TradingEnv`` to simulate trading.
+
+Usage:
+    python start_trader.py data/historical.csv trained_dqn.pth
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from start_ai import load_recent_data
+from indicators import get_all_indicators
+from ai_module import TradingEnv, TradingDQN
+from config import RL_ENV_PARAMS
+
+try:
+    import torch
+except Exception:  # pragma: no cover
+    torch = None
+
+logger = logging.getLogger(__name__)
+
+
+def load_model(path: Path) -> TradingDQN:
+    """Restore a DQN model from disk if available."""
+    agent = TradingDQN(RL_ENV_PARAMS["state_size"], RL_ENV_PARAMS["action_size"])
+    if agent.model and torch is not None and path.is_file():
+        agent.model.load_state_dict(torch.load(path))
+        agent.epsilon = 0  # Use greedy policy for execution
+        logger.info("Loaded model from %s", path)
+    else:
+        logger.warning("Using untrained DQN agent; actions will be random")
+    return agent
+
+
+def main(csv_path: str, model_path: str) -> None:
+    df = load_recent_data(csv_path, years=1)
+    df = get_all_indicators(df)
+    env = TradingEnv(df)
+    agent = load_model(Path(model_path))
+    state, _ = env.reset()
+    total_reward = 0.0
+    for _ in range(len(df) - 1):
+        action = agent.act(state)
+        state, reward, done, _, _ = env.step(action)
+        total_reward += reward
+        if done:
+            break
+    print(f"Total simulated reward: {total_reward:.2f}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    if len(sys.argv) < 3:
+        print("Usage: python start_trader.py path/to/historical.csv trained_dqn.pth")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary
- parallelize multi-timeframe backtests and train a DQN agent that saves to `trained_dqn.pth`
- add `start_trader.py` to replay market data with a saved DQN model

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b6898bee1083279008304bbf9da992