### PR TITLE
Introduce self-learning strategy evolution and weighted trader

### DIFF
--- a/metatrader5_stub.py
+++ b/metatrader5_stub.py
@@ -64,3 +64,7 @@ def positions_get(*args, **kwargs):
 
 def order_send(request):
     return OrderSendResult()
+
+
+def last_error():
+    return (0, "stub")

--- a/start_ai.py
+++ b/start_ai.py
@@ -1,0 +1,129 @@
+"""Utility script to run multi-timeframe backtests and prepare an RL environment.
+
+The script loads up to five years of historical data from a CSV file, computes a
+large set of indicators, applies up to 300 available strategies, and reports the
+Sharpe ratio for each strategy across multiple timeframes. It also instantiates
+the reinforcement learning environment defined in ``ai_module`` so further
+training can be layered on top. The heavy lifting of computing hundreds of
+indicators and strategy variations is handled by ``indicators.py`` and
+``strategies.py``.
+
+Usage:
+    # From CSV data
+    python start_ai.py data/historical.csv
+
+    # Or fetch directly from MetaTrader 5 (requires valid login in config.py)
+    python start_ai.py EURUSD
+
+The CSV must contain columns: Date, Open, High, Low, Close, Volume.  When a
+symbol is provided instead of a CSV file the script will attempt to download
+the most recent data from MetaTrader 5 and fall back to a synthetic data source
+if MT5 is unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import timedelta
+from typing import List
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pandas as pd
+
+import strategies
+from indicators import get_all_indicators
+from backtester import backtest
+from strategy_manager import StrategyManager
+from ai_module import TradingEnv, AIModule
+from config import RL_ENV_PARAMS
+from broker_interface import MT5Broker, MockBroker
+
+try:  # Optional torch dependency for saving trained models
+    import torch
+except Exception:  # pragma: no cover - torch is optional
+    torch = None
+
+logger = logging.getLogger(__name__)
+
+
+def load_recent_data(source: str, years: int = 5, timeframe: str = "TIMEFRAME_M1") -> pd.DataFrame:
+    """Load recent price data from a CSV file or MetaTrader 5.
+
+    Parameters
+    ----------
+    source:
+        Path to a CSV file or a symbol name to fetch via MT5.
+    years:
+        Number of years of data to keep/fetch.
+    timeframe:
+        MT5 timeframe constant when ``source`` is a symbol.
+    """
+    if os.path.isfile(source):
+        df = pd.read_csv(source, parse_dates=["Date"])
+        end = df["Date"].max()
+        start = end - timedelta(days=years * 365)
+        return df[df["Date"].between(start, end)].set_index("Date")
+
+    # Otherwise try to pull data from MetaTrader 5
+    try:
+        broker = MT5Broker()
+    except Exception as e:  # pragma: no cover - MT5 may be missing in tests
+        logger.warning("MT5 unavailable (%s); using MockBroker", e)
+        broker = MockBroker()
+
+    bars_per_year = {
+        "TIMEFRAME_M1": 365 * 24 * 60,
+        "TIMEFRAME_H1": 365 * 24,
+        "TIMEFRAME_D1": 365,
+    }
+    count = bars_per_year.get(timeframe, 365 * 24 * 60) * years
+    count = min(count, 100_000)  # Avoid huge downloads
+    return broker.get_historical_data(source, timeframe, count)
+
+
+def run_multi_timeframe_backtests(df: pd.DataFrame, timeframes: List[str]) -> None:
+    """Run backtests for each strategy and timeframe, logging Sharpe ratios."""
+    strategy_names = list(strategies.strategies.keys())[:300]
+    StrategyManager(strategy_names)  # Ensure strategies are validated
+
+    def _run(strat: str, tf: str) -> tuple[str, str, float]:
+        result = backtest(df.copy(), strat, timeframe=tf)
+        return strat, tf, result["sharpe"]
+
+    for tf in timeframes:
+        logger.info("Running %s backtests with %d strategies", tf, len(strategy_names))
+        with ThreadPoolExecutor() as executor:
+            futures = {executor.submit(_run, strat, tf): strat for strat in strategy_names}
+            for future in as_completed(futures):
+                strat, timeframe, sharpe = future.result()
+                logger.info("%s @ %s Sharpe: %.4f", strat, timeframe, sharpe)
+
+
+def train_rl_agent(df: pd.DataFrame) -> None:
+    """Train the DQN agent on the provided data and persist the model if possible."""
+    env = TradingEnv(df)
+    ai = AIModule()
+    ai.init_dqn(RL_ENV_PARAMS["state_size"], RL_ENV_PARAMS["action_size"])
+    ai.train_dqn(env, episodes=10, batch_size=32)
+    if ai.dqn and ai.dqn.model and torch is not None:
+        torch.save(ai.dqn.model.state_dict(), "trained_dqn.pth")
+        logger.info("Saved trained DQN model to trained_dqn.pth")
+
+
+def main(source: str) -> None:
+    df = load_recent_data(source)
+    df = get_all_indicators(df)
+    run_multi_timeframe_backtests(df, ["M1", "H1", "D1"])
+    env = TradingEnv(df)
+    logger.info("RL environment with %d steps ready", len(df))
+    train_rl_agent(df)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    if len(sys.argv) < 2:
+        print("Usage: python start_ai.py <csv path or symbol>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/start_self_learning_ai.py
+++ b/start_self_learning_ai.py
@@ -1,0 +1,112 @@
+"""Autonomous training script for the trading AI.
+
+This script loads up to five years of price data, computes a large set of
+indicators, evaluates hundreds of strategies over multiple timeframes and
+performs a simple evolutionary search to derive new weighted meta-strategies.
+The best strategy weights are saved to ``best_weights.json`` and a DQN agent is
+trained (or further trained) on the enriched dataset.
+
+Usage:
+    python start_self_learning_ai.py <csv path or symbol>
+
+The script reuses utility functions from ``start_ai.py`` for data loading and
+backtesting.  It is intentionally lightweight and serves as a foundation for
+more advanced research such as adding genetic operators or extended indicator
+sets.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+import strategies
+from backtester import backtest
+from strategy_manager import StrategyManager
+from indicators import get_all_indicators
+from start_ai import load_recent_data, run_multi_timeframe_backtests
+from ai_module import TradingEnv, AIModule
+from config import RL_ENV_PARAMS
+
+try:  # Optional torch dependency
+    import torch
+except Exception:  # pragma: no cover - torch is optional
+    torch = None
+
+logger = logging.getLogger(__name__)
+
+
+def _temp_strategy_factory(weights: Dict[str, float]):
+    """Return a callable that aggregates signals using provided weights."""
+
+    def _temp(df):
+        sm = StrategyManager(list(weights.keys()), weights)
+        return sm.apply_strategies(df)["aggregate"]
+
+    return _temp
+
+
+def evolve_strategy_weights(df, generations: int = 5, population: int = 10) -> Dict[str, float]:
+    """Randomly search strategy weightings to maximise Sharpe ratio.
+
+    Parameters
+    ----------
+    df:
+        Price data enriched with indicators.
+    generations:
+        Number of generations to iterate.
+    population:
+        Candidate solutions per generation.
+    """
+    strategy_names = list(strategies.strategies.keys())[:300]
+    best_weights: Dict[str, float] | None = None
+    best_sharpe = float("-inf")
+
+    for g in range(generations):
+        for _ in range(population):
+            weights = {s: float(np.random.rand()) for s in strategy_names}
+            result = backtest(df, "temp", temp_strategy=_temp_strategy_factory(weights))
+            sharpe = result["sharpe"]
+            if sharpe > best_sharpe:
+                best_sharpe, best_weights = sharpe, weights
+                logger.info("Gen %d new best Sharpe %.4f", g, sharpe)
+
+    return best_weights if best_weights is not None else {}
+
+
+def train_continuous_dqn(df) -> None:
+    """Train the DQN agent and persist the model, resuming if possible."""
+    env = TradingEnv(df)
+    ai = AIModule()
+    ai.init_dqn(RL_ENV_PARAMS["state_size"], RL_ENV_PARAMS["action_size"])
+    model_path = Path("trained_dqn.pth")
+    if ai.dqn and torch is not None and model_path.is_file():
+        ai.dqn.model.load_state_dict(torch.load(model_path))
+        logger.info("Loaded existing DQN model for continued training")
+    ai.train_dqn(env, episodes=50, batch_size=64)
+    if ai.dqn and ai.dqn.model and torch is not None:
+        torch.save(ai.dqn.model.state_dict(), model_path)
+        logger.info("Saved trained DQN model to %s", model_path)
+
+
+def main(source: str) -> None:
+    df = load_recent_data(source, years=5)
+    df = get_all_indicators(df)
+    run_multi_timeframe_backtests(df, ["M1", "H1", "D1"])
+    weights = evolve_strategy_weights(df)
+    with open("best_weights.json", "w") as f:
+        json.dump(weights, f, indent=2)
+    logger.info("Persisted best strategy weights to best_weights.json")
+    train_continuous_dqn(df)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    if len(sys.argv) < 2:
+        print("Usage: python start_self_learning_ai.py <csv path or symbol>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/start_trader.py
+++ b/start_trader.py
@@ -1,0 +1,83 @@
+"""Run a trading simulation using a previously trained DQN model.
+
+The script loads recent market data, computes indicators, restores a saved
+DQN model and executes actions within the ``TradingEnv`` to simulate trading.
+
+Usage:
+    # From CSV data
+    python start_trader.py data/historical.csv trained_dqn.pth
+
+    # Or fetch data from MetaTrader 5 using a symbol
+    python start_trader.py EURUSD trained_dqn.pth
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+from start_ai import load_recent_data
+from indicators import get_all_indicators
+from ai_module import TradingEnv, TradingDQN
+from config import RL_ENV_PARAMS
+from strategy_manager import StrategyManager
+
+try:
+    import torch
+except Exception:  # pragma: no cover
+    torch = None
+
+logger = logging.getLogger(__name__)
+
+
+def load_model(path: Path) -> TradingDQN:
+    """Restore a DQN model from disk if available."""
+    agent = TradingDQN(RL_ENV_PARAMS["state_size"], RL_ENV_PARAMS["action_size"])
+    if agent.model and torch is not None and path.is_file():
+        agent.model.load_state_dict(torch.load(path))
+        agent.epsilon = 0  # Use greedy policy for execution
+        logger.info("Loaded model from %s", path)
+    else:
+        logger.warning("Using untrained DQN agent; actions will be random")
+    return agent
+
+
+def load_strategy_signals(df):
+    """Load optimised strategy weights if available and return signals."""
+    path = Path("best_weights.json")
+    if not path.is_file():
+        return None
+    with path.open() as f:
+        weights = json.load(f)
+    sm = StrategyManager(list(weights.keys()), weights)
+    return sm.apply_strategies(df)["aggregate"].values
+
+
+def main(source: str, model_path: str) -> None:
+    df = load_recent_data(source, years=1)
+    df = get_all_indicators(df)
+    signals = load_strategy_signals(df)
+    env = TradingEnv(df)
+    agent = load_model(Path(model_path))
+    state, _ = env.reset()
+    total_reward = 0.0
+    for i in range(len(df) - 1):
+        if signals is not None and signals[i] != 0:
+            action = 0 if signals[i] > 0 else 2
+        else:
+            action = agent.act(state)
+        state, reward, done, _, _ = env.step(action)
+        total_reward += reward
+        if done:
+            break
+    print(f"Total simulated reward: {total_reward:.2f}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    if len(sys.argv) < 3:
+        print("Usage: python start_trader.py <csv path or symbol> trained_dqn.pth")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])

--- a/strategies.py
+++ b/strategies.py
@@ -2521,3 +2521,10 @@ def evolved_macd_477(df, multi_data=None, sym=None, news_bias=0):
     macd, signal, hist = talib.MACD(df['Close'], fastperiod=9, slowperiod=23, signalperiod=5)
     return np.where(macd > signal, 1, np.where(macd < signal, -1, 0))
 
+
+
+# New strategy: evolved_macd_627
+def evolved_macd_627(df, multi_data=None, sym=None, news_bias=0):
+    macd, signal, hist = talib.MACD(df['Close'], fastperiod=5, slowperiod=38, signalperiod=11)
+    return np.where(macd > signal, 1, np.where(macd < signal, -1, 0))
+


### PR DESCRIPTION
## Summary
- add `start_self_learning_ai.py` to evolve strategy weights and resume DQN training over five years of data
- enhance `start_trader.py` to apply the evolved strategy weights during simulations

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b6898bee1083279008304bbf9da992